### PR TITLE
Reset ReadOnly file attribute before setting times

### DIFF
--- a/DateFixer/Program.cs
+++ b/DateFixer/Program.cs
@@ -116,8 +116,14 @@ namespace DateFixer
                 {
                     try
                     {
+                        var attributes = File.GetAttributes(path);
+                        File.SetAttributes(path, FileAttributes.Normal);
+
                         File.SetLastWriteTimeUtc(path, (DateTime)creationTime);
                         File.SetCreationTimeUtc(path, (DateTime)creationTime);
+
+                        File.SetAttributes(path, attributes);
+
                         Console.WriteLine(Path.GetFileName(path) + " -> " + ((DateTime)creationTime).ToString());
                     } catch (Exception) { }
                 }


### PR DESCRIPTION
This commit fixes a potential `UnauthorizedAccessException` when a file has the "ReadOnly" attribute.
The file attributes are temporarily reset to "Normal" before setting write and creation times, and are reset to their previous values afterwards.